### PR TITLE
Clarfied Readme instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Much of this code is messy, uses unusual solutions, and does not hold to our est
 - [PixHammer's GameBoy Shader](https://pixhammer.itch.io/gameboy-shader)
 
 ## Installation
-This repository, being based on YellowAfterlife's source reconstruction, is installed in a very similar fashion. but replace 1.1's `data.win` with the latest Community Update `AM2R.exe`.
+This repository, being based on YellowAfterlife's source reconstruction, is installed in a very similar fashion.
 
-1. Download all Requirements above.
+1. Download all everything from the requirements section above.
 2. Download and extract [this repository](https://github.com/AM2R-Community-Developers/AM2R-Community-Updates/archive/refs/heads/main.zip) somewhere.
 3. Go to where you have your AM2Rlauncher located, then into the `Profiles` folder, and after that the `Community Updates (Latest)`. Place the `AM2R.exe` file from there into the project directory.  
-PIC!!!!
+![https://cdn.discordapp.com/attachments/509717926807601182/841708939980570655/unknown.png](https://cdn.discordapp.com/attachments/509717926807601182/841708939980570655/unknown.png)
 4. Drag the `AM2R.exe` file onto the GmxDataSync executable. If everything is correct, this will populate the project  with art/audio assets from the binary.  
-PIC!!!
+![https://cdn.discordapp.com/attachments/509717926807601182/841709919542706176/unknown.png](https://cdn.discordapp.com/attachments/509717926807601182/841709919542706176/unknown.png)
 5. Replace the two blank shader assets with default GM:S shader skeletons or your own copy of each shader, as well as the accompanying script files for the Retro Palette Swapper: `pal_swap_init_system` and `pal_swap_set`.
 **WARNING:** If the two above scripts are not replaced *before* opening the project file, GM:S 1.4 will replace them with `<undefined>` references in the asset tree at `Scripts/Lojical/Shaders/`. This will produce numerous seemingly unrelated errors until they are deleted and replaced with the appropriately named scripts.
 6. Finally, you will need to install `modifiers.ini` as well as the `lang` and `mods` folders as datafiles within the GM:S project. The default ones do not contain the actual assets and are merely references. These can be copied from your `Community Updates (Latest)` folder.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AM2R-Community-Updates
 
+**Please do not request help until you have read this entire document. The vast majority of your questions should be answered within it, and we will be able to easily tell if you have not followed the installation instructions thoroughly.**
+
 ## What is this?
 The source code for the AM2R Community Updates 1.5.x branch, free of copyrighted assets and trademarks.
 If you have not played the AM2R Community Updates before, this will be of no use to you!
@@ -61,7 +63,3 @@ This repository, being based on YellowAfterlife's source reconstruction, is inst
 **WARNING:** If the two above scripts are not replaced *before* opening the project file, GM:S 1.4 will replace them with `<undefined>` references in the asset tree at `Scripts/Lojical/Shaders/`. This will produce numerous seemingly unrelated errors until they are deleted and replaced with the appropriately named scripts.
 6. Finally, you will need to install `modifiers.ini` as well as the `lang` and `mods` folders as datafiles within the GM:S project. The default ones do not contain the actual assets and are merely references. These can be copied from your `Community Updates (Latest)` folder.
 7. [optional] Copy music files (.ogg) from game directory into "audio" directory inside the "sound" directory of the project (the game will still work without music, though).
-8. [optional] Edit datafiles/lang/english.ini to use original names (if you are concerned).
-
-**NOTE:** Read these instructions!!! Do NOT come to us with project issues unless you are SURE you have followed EVERY STEP in these instructions.
-

--- a/README.md
+++ b/README.md
@@ -38,19 +38,30 @@ Reordering assets created before the Community Updates began can have consequenc
 Much of this code is messy, uses unusual solutions, and does not hold to our established formatting style - this is a result of AM2R's reconstruction and nature as a learning project passed down to multiple lead developers.
 
 ## Requirements
-[GameMaker: Studio 1.4.1763](https://store.yoyogames.com/downloads/gm-studio/GMStudio-Installer-1.4.1763.exe) - the IDE for editing and compiling this project.
+- [GameMaker: Studio 1.4.1763](https://store.yoyogames.com/downloads/gm-studio/GMStudio-Installer-1.4.1763.exe) - the IDE for editing and compiling this project.
 
-[GMXDataSync](https://raw.githubusercontent.com/YAL-GameMaker-Tools/GmxDataSync/master/Executable/GmxDataSync.exe) - a utility created by YellowAfterlife to populate project files with matching game assets.
+- [GMXDataSync](https://raw.githubusercontent.com/YAL-GameMaker-Tools/GmxDataSync/master/Executable/GmxDataSync.exe) - a utility created by YellowAfterlife to populate project files with matching game assets.
 
-A copy of the latest release build of the AM2R Community Updates, which can be installed via the [AM2RLauncher](https://www.reddit.com/r/AM2R/comments/me73i2/am2rlauncher_20_release_now_with_linux_support/).
+- A copy of the latest release build of the AM2R Community Updates, which can be installed via the [AM2RLauncher](https://www.reddit.com/r/AM2R/comments/me73i2/am2rlauncher_20_release_now_with_linux_support/).
+
+- [Pixelated Pope's Retro Palette Swapper](https://pixelatedpope.itch.io/retro-palette-swapper) - as said above, make **absolutely** sure you get the GameMaker: Studio 1.4 version! It's a .gmz file, **not** a .yyz file!
+
+- [PixHammer's GameBoy Shader](https://pixhammer.itch.io/gameboy-shader)
 
 ## Installation
-This repository, being based on YellowAfterlife's source reconstruction, is installed in a very similar fashion. Please refer to his installation instructions [here](https://gitlab.com/yellowafterlife/AM2Rrc/-/tree/master/), but replace 1.1's `data.win` with the latest Community Update `AM2R.exe`.
+This repository, being based on YellowAfterlife's source reconstruction, is installed in a very similar fashion. but replace 1.1's `data.win` with the latest Community Update `AM2R.exe`.
 
-**NOTE:** Read YAL's instructions!!! Do NOT come to us with project issues unless you are SURE you have followed EVERY STEP in his instructions, and then the ones below.
-
-Afterwards, replace the two blank shader assets with default GM:S shader skeletons or your own copy of each shader, as well as the accompanying script files for the Retro Palette Swapper: `pal_swap_init_system` and `pal_swap_set`.
-
+1. Download all Requirements above.
+2. Download and extract [this repository](https://github.com/AM2R-Community-Developers/AM2R-Community-Updates/archive/refs/heads/main.zip) somewhere.
+3. Go to where you have your AM2Rlauncher located, then into the `Profiles` folder, and after that the `Community Updates (Latest)`. Place the `AM2R.exe` file from there into the project directory.  
+PIC!!!!
+4. Drag the `AM2R.exe` file onto the GmxDataSync executable. If everything is correct, this will populate the project  with art/audio assets from the binary.  
+PIC!!!
+5. Replace the two blank shader assets with default GM:S shader skeletons or your own copy of each shader, as well as the accompanying script files for the Retro Palette Swapper: `pal_swap_init_system` and `pal_swap_set`.
 **WARNING:** If the two above scripts are not replaced *before* opening the project file, GM:S 1.4 will replace them with `<undefined>` references in the asset tree at `Scripts/Lojical/Shaders/`. This will produce numerous seemingly unrelated errors until they are deleted and replaced with the appropriately named scripts.
+6. Finally, you will need to install `modifiers.ini` as well as the `lang` and `mods` folders as datafiles within the GM:S project. The default ones do not contain the actual assets and are merely references. These can be copied from your `Community Updates (Latest)` folder.
+7. [optional] Copy music files (.ogg) from game directory into "audio" directory inside the "sound" directory of the project (the game will still work without music, though).
+8. [optional] Edit datafiles/lang/english.ini to use original names (if you are concerned).
 
-Finally, you will need to install `modifiers.ini` as well as the `lang` and `mods` folders as datafiles within the GM:S project. The default ones do not contain the actual assets and are merely references. These can be copied over from your AM2R_15_2 folder.
+**NOTE:** Read these instructions!!! Do NOT come to us with project issues unless you are SURE you have followed EVERY STEP in these instructions.
+


### PR DESCRIPTION
I rewrote parts of the Readme in order to make it a little more simple.
- Linked the Shaders as requirements
- Provded more detailed installation details, heavily inspired by YellowAfterLife's Gitlab repo, so that people don't have to switch sites
