### PR TITLE
Equally divide analog stick to 8 parts

### DIFF
--- a/scripts/check_keys.gml
+++ b/scripts/check_keys.gml
@@ -160,19 +160,24 @@ if (gamepad_is_supported()) {
         xjoyy = gamepad_axis_value(global.gamepadIndex, gp_axislv);
         if (is_walkzone(xjoyx, xjoyy, 1)) walk_zone = 1;
         if (is_past_deadzone(xjoyx, xjoyy, 1)) {
-            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx < -(global.opxjoydz / 200))) {
+
+            stickAngle = point_direction(0, 0, xjoyx, xjoyy)
+            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx < -(global.opxjoydz / 200))) && stickAngle > 112.5 && stickAngle < 247.5  {
                 ctrl_Left = -xjoyx;
                 global.controltype = 2;
             }
-            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx > (global.opxjoydz / 200))) {
+			
+            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx > (global.opxjoydz / 200))) && (stickAngle <= 67.5 || stickAngle >= 292.5) {
                 ctrl_Right = xjoyx;
                 global.controltype = 2;
             }
-            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy < -(global.opxjoydz / 200))) {
+			
+            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy < -(global.opxjoydz / 200))) && stickAngle <= 157.5 && stickAngle >= 22.5 {
                 ctrl_Up = 1;
                 global.controltype = 2;
             }
-            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy > (global.opxjoydz / 200))) {
+			
+            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy > (global.opxjoydz / 200))) && stickAngle > 202.5 && stickAngle < 337.5 {
                 ctrl_Down = 1;
                 global.controltype = 2;
             }

--- a/scripts/check_keys.gml
+++ b/scripts/check_keys.gml
@@ -161,8 +161,9 @@ if (gamepad_is_supported()) {
         if (is_walkzone(xjoyx, xjoyy, 1)) walk_zone = 1;
         if (is_past_deadzone(xjoyx, xjoyy, 1)) {
 
-            stickAngle = point_direction(0, 0, xjoyx, xjoyy)
-            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx < -(global.opxjoydz / 200))) && stickAngle > 112.5 && stickAngle < 247.5  {
+            stickAngle = point_direction(0, 0, xjoyx, xjoyy);
+
+            if ((ctrl_Left == 0) && (ctrl_Right == 0) && (xjoyx < -(global.opxjoydz / 200))) && (stickAngle > 112.5 && stickAngle < 247.5)  {
                 ctrl_Left = -xjoyx;
                 global.controltype = 2;
             }
@@ -172,12 +173,12 @@ if (gamepad_is_supported()) {
                 global.controltype = 2;
             }
 			
-            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy < -(global.opxjoydz / 200))) && stickAngle <= 157.5 && stickAngle >= 22.5 {
+            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy < -(global.opxjoydz / 200))) && (stickAngle <= 157.5 && stickAngle >= 22.5) {
                 ctrl_Up = 1;
                 global.controltype = 2;
             }
 			
-            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy > (global.opxjoydz / 200))) && stickAngle > 202.5 && stickAngle < 337.5 {
+            if ((ctrl_Up == 0) && (ctrl_Down == 0) && (xjoyy > (global.opxjoydz / 200))) && (stickAngle > 202.5 && stickAngle < 337.5) {
                 ctrl_Down = 1;
                 global.controltype = 2;
             }


### PR DESCRIPTION
(This is my first code pull request; I'm not really sure if this is what I should do/how this works)

As it is currently, the analog stick is very biased towards diagonal directions, and it's very hard to aim forward/up/down. This fixes the issue by dividing the stick to 8 parts, one for each direction.